### PR TITLE
refactor: provide 'noLocalFiles' property to all inheritors of AbstractPrince

### DIFF
--- a/src/main/java/com/princexml/wrapper/AbstractPrince.java
+++ b/src/main/java/com/princexml/wrapper/AbstractPrince.java
@@ -38,6 +38,7 @@ abstract class AbstractPrince {
     protected boolean iframes;
     protected boolean xInclude;
     protected boolean xmlExternalEntities;
+    protected boolean noLocalFiles;
 
     // Network options.
     private boolean noNetwork;
@@ -409,6 +410,14 @@ abstract class AbstractPrince {
      */
     public void setXmlExternalEntities(boolean xmlExternalEntities) {
         this.xmlExternalEntities = xmlExternalEntities;
+    }
+
+    /**
+     * Disable access to local files. Default value is {@code false}.
+     * @param noLocalFiles true to disable local files.
+     */
+    public void setNoLocalFiles(boolean noLocalFiles) {
+        this.noLocalFiles = noLocalFiles;
     }
     //endregion
 

--- a/src/main/java/com/princexml/wrapper/Prince.java
+++ b/src/main/java/com/princexml/wrapper/Prince.java
@@ -22,7 +22,6 @@ import static com.princexml.wrapper.CommandLine.*;
 public class Prince extends AbstractPrince {
     // Input options.
     private final List<String> remaps = new ArrayList<>();
-    private boolean noLocalFiles;
 
     // CSS options.
     private String pageSize;
@@ -448,13 +447,6 @@ public class Prince extends AbstractPrince {
         this.remaps.clear();
     }
 
-    /**
-     * Disable access to local files. Default value is {@code false}.
-     * @param noLocalFiles true to disable local files.
-     */
-    public void setNoLocalFiles(boolean noLocalFiles) {
-        this.noLocalFiles = noLocalFiles;
-    }
     //endregion
 
     //region CSS options.

--- a/src/main/java/com/princexml/wrapper/PrinceControl.java
+++ b/src/main/java/com/princexml/wrapper/PrinceControl.java
@@ -208,17 +208,19 @@ public class PrinceControl extends AbstractPrince {
         json.field("compress", !noCompress);
         json.field("object-streams", !noObjectStreams);
 
-        json.beginObj("encrypt");
-        if (keyBits != null) { json.field("key-bits", keyBits.getValue()); }
-        if (userPassword != null) { json.field("user-password", userPassword); }
-        if (ownerPassword != null) { json.field("owner-password", ownerPassword); }
-        json.field("disallow-print", disallowPrint);
-        json.field("disallow-modify", disallowModify);
-        json.field("disallow-copy", disallowCopy);
-        json.field("disallow-annotate", disallowAnnotate);
-        json.field("allow-copy-for-accessibility", allowCopyForAccessibility);
-        json.field("allow-assembly", allowAssembly);
-        json.endObj();
+        if(encrypt) {
+            json.beginObj("encrypt");
+            if (keyBits != null) { json.field("key-bits", keyBits.getValue()); }
+            if (userPassword != null) { json.field("user-password", userPassword); }
+            if (ownerPassword != null) { json.field("owner-password", ownerPassword); }
+            json.field("disallow-print", disallowPrint);
+            json.field("disallow-modify", disallowModify);
+            json.field("disallow-copy", disallowCopy);
+            json.field("disallow-annotate", disallowAnnotate);
+            json.field("allow-copy-for-accessibility", allowCopyForAccessibility);
+            json.field("allow-assembly", allowAssembly);
+            json.endObj();
+        }
 
         if (pdfProfile != null) { json.field("pdf-profile", pdfProfile.toString()); }
         if (pdfOutputIntent != null) { json.field("pdf-output-intent", pdfOutputIntent); }

--- a/src/main/java/com/princexml/wrapper/PrinceControl.java
+++ b/src/main/java/com/princexml/wrapper/PrinceControl.java
@@ -198,6 +198,7 @@ public class PrinceControl extends AbstractPrince {
         json.field("iframes", iframes);
         json.field("xinclude", xInclude);
         json.field("xml-external-entities", xmlExternalEntities);
+        json.field("no-local-files", noLocalFiles);
         json.endObj();
 
         json.beginObj("pdf");

--- a/src/test/java/com/princexml/wrapper/PrinceControlTest.java
+++ b/src/test/java/com/princexml/wrapper/PrinceControlTest.java
@@ -113,6 +113,7 @@ class PrinceControlTest {
         p.setMaxPasses(5);
         p.setXInclude(true);
         p.setXmlExternalEntities(true);
+        p.setNoLocalFiles(true);
         p.setIframes(true);
 
         p.setNoEmbedFonts(true);


### PR DESCRIPTION
Provides 'noLocalFiles' property to all inheritors of AbstractPrince. Consequently, PrinceControl can add this field to the JSON job description.